### PR TITLE
Multi-line SQL Paste and Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ commands (querying, plotting, previews) so they can evolve independently of the 
 - DuckDB-powered SQL querying with optional data visualisation
 - Interactive, multi-line SQL prompt for composing queries
 - Session defaults via `csv:set:*` helpers (file, axes, filters, plot metadata)
-- Scatter, line, and bar chart support with matplotlib overlays, custom axis scales/ranges, and binary segmentation
+- Scatter, line, and bar chart support with matplotlib overlays, custom axis scales/ranges, and categorical segmentation
 - Head/tail previews, configurable pagers, and saved output targets
 - Automatic integration with caddie’s prompt and completion registries
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -104,8 +104,8 @@ You can combine the supported syntax in any order:
 | Axis scale              | `x_scale=<mode>` `y_scale=<mode>` | Applies matplotlib scaling (e.g., `linear`, `log`, `symlog`) |
 | Axis range              | `x_range=<spec>` `y_range=<spec>` | Comma list with optional brackets/parentheses; blanks mean open bounds |
 | Filter → scatter_filter | `where <predicate>`            | Copied verbatim to `csv:set:scatter_filter`          |
-| Segment column          | `segment=<column>`             | Sets `csv:set:segment_column` for binary coloring    |
-| Segment colors          | `segment_colors <c1,c2>`       | Optional palette override mapped to segment values  |
+| Segment column          | `segment=<column>`             | Sets `csv:set:segment_column` for categorical coloring |
+| Segment colors          | `segment_colors <c1,c2,...>`    | Optional palette override mapped to segment values  |
 | Title                   | `title: <text>`                | Title set up to the next keyword (e.g., `save to`)   |
 | Save path               | `save to path.png`             | Passed to `csv:set:save`. (HTML is allowed for consistency; rendering remains matplotlib.) |
 | Define SQL              | `sql: <query>`                 | Passed to `csv:set:sql` (e.g., `sql: select * from df where success=false`) |
@@ -603,6 +603,7 @@ caddie[csv sql]-1.4> SELECT distance,
 ##### `caddie csv:set:pager <command>`
 
 Control which pager is used for full query output. When unset, caddie prefers `less` (if installed), then `more`, and finally falls back to `cat`.
+When `less` is auto-detected and `$LESS` is unset, the module runs it with `-R -F -X` so the results stay on the current screen and `less` exits automatically when the content fits one page.
 
 **Examples:**
 ```bash
@@ -744,10 +745,10 @@ caddie csv:set:scatter_filter "distance_to_hole < 50"
 
 ##### `caddie csv:set:segment_column <column>`
 
-Assign a binary column that will be used to color scatter plot points.
+Assign a categorical column that will be used to color scatter plot points.
 
 **Arguments:**
-- `column`: Column name in the result set that contains two distinct values (excluding NULL)
+- `column`: Column name in the result set that contains categorical values (NULL permitted)
 
 **Examples:**
 ```bash
@@ -763,12 +764,12 @@ caddie csv:set:segment_column made_putt
 ✓ Set segment column to success
 ```
 
-##### `caddie csv:set:segment_colors <color1,color2>`
+##### `caddie csv:set:segment_colors <color1,color2,...>`
 
 Override the default color palette for the segment column.
 
 **Arguments:**
-- `color1,color2`: Comma-separated matplotlib colors or hex codes (applied in the order values appear)
+- `color1,color2,...`: Comma-separated matplotlib colors or hex codes (provide at least as many colors as distinct segment values)
 
 **Examples:**
 ```bash
@@ -1070,8 +1071,8 @@ All CSV module settings map to environment variables with the `CADDIE_CSV_` pref
 | `y_scale` | `CADDIE_CSV_Y_SCALE` | Matplotlib scale for y-axis |
 | `x_range` | `CADDIE_CSV_X_RANGE` | Axis bounds and ticks override for x-axis |
 | `y_range` | `CADDIE_CSV_Y_RANGE` | Axis bounds and ticks override for y-axis |
-| `segment_column` | `CADDIE_CSV_SEGMENT_COLUMN` | Binary column used to color scatter plots |
-| `segment_colors` | `CADDIE_CSV_SEGMENT_COLORS` | Custom colors for binary segment groups |
+| `segment_column` | `CADDIE_CSV_SEGMENT_COLUMN` | Categorical column used to color scatter plots |
+| `segment_colors` | `CADDIE_CSV_SEGMENT_COLORS` | Custom colors for segment groups (comma-separated) |
 | `circle` | `CADDIE_CSV_CIRCLE` | Enable circle overlay |
 | `rings` | `CADDIE_CSV_RINGS` | Enable ring overlay |
 | `circle_x` | `CADDIE_CSV_CIRCLE_X` | Circle center X position |
@@ -1115,8 +1116,8 @@ caddie csv:set:y_range (-3,3)
 caddie csv:plot --title "Centered dispersion window"
 ```
 
-When a segment column is set, the tool automatically renders each binary value
-with a distinct color (teal/orange by default) and adds a legend. Missing values
+When a segment column is set, the tool automatically renders each distinct value
+with a distinct color (teal/orange/purple by default, expanding via Matplotlib palettes when more are needed) and adds a legend. Missing values
 are shown in grey so they remain easy to spot without overwhelming the chart.
 
 ### Line Plots

--- a/modules/dot_caddie_csv.sh
+++ b/modules/dot_caddie_csv.sh
@@ -590,10 +590,10 @@ function caddie_csv_sql_help_internal() {
 }
 
 function caddie_csv_sql_paste_mode() {
-    caddie cli:title "Multiline Paste Mode"
-    caddie cli:indent "Paste your multiline SQL query below."
-    caddie cli:indent "Press Ctrl+D (EOF) when finished, or type 'END' on a new line."
-    caddie cli:blank
+    caddie cli:title "Multiline Paste Mode" >&2
+    caddie cli:indent "Paste your multiline SQL query below." >&2
+    caddie cli:indent "Press Ctrl+D (EOF) when finished, or type 'END' on a new line." >&2
+    caddie cli:blank >&2
     
     local paste_buffer=""
     local line=""
@@ -610,7 +610,7 @@ function caddie_csv_sql_paste_mode() {
         # Return the pasted content to be added to the main buffer
         printf '%s' "$paste_buffer"
     else
-        caddie cli:warning "No content pasted"
+        caddie cli:warning "No content pasted" >&2
     fi
     
     return 0
@@ -679,7 +679,7 @@ function caddie_csv_sql() {
     caddie cli:title "Interactive CSV SQL prompt"
     caddie cli:indent "Enter SQL across multiple lines and finish with ';' or \\g."
     caddie cli:indent "Type \\help for available commands."
-    caddie cli:indent "For multiline paste: use \\paste command (cleaner) or paste directly."
+    caddie cli:indent "For clean multiline paste: use \\paste command."
 
     # Initialize history index
     caddie_csv_sql_reset_history_index
@@ -762,7 +762,7 @@ function caddie_csv_sql() {
                     fi
                     continue
                     ;;
-                \\history)
+                \\history*)
                     # Check if there's a number argument
                     if [[ "$line" =~ ^\\history[[:space:]]+([0-9]+)$ ]]; then
                         local hist_num="${BASH_REMATCH[1]}"

--- a/modules/dot_caddie_csv.sh
+++ b/modules/dot_caddie_csv.sh
@@ -575,8 +575,8 @@ function caddie_csv_sql_help_internal() {
     caddie cli:indent "\\summary  Execute the current buffer as a summary query"
     caddie cli:indent "\\show     Display active CSV defaults"
     caddie cli:indent "\\last     Show the last stored SQL statement"
-    caddie cli:indent "\\hist     Show SQL command history"
-    caddie cli:indent "\\history  Load specific command from history (e.g., \\history 3)"
+    caddie cli:indent "\\history  Show command history (\\history) or load specific command (\\history N)"
+    caddie cli:indent "\\hist     Alias for \\history"
     caddie cli:indent "\\up       Go to previous command in history"
     caddie cli:indent "\\down     Go to next command in history"
     caddie cli:indent "\\clear    Discard the in-flight SQL buffer"
@@ -762,10 +762,10 @@ function caddie_csv_sql() {
                     fi
                     continue
                     ;;
-                \\history*)
+                \\history*|\\hist)
                     # Check if there's a number argument
-                    if [[ "$line" =~ ^\\history[[:space:]]+([0-9]+)$ ]]; then
-                        local hist_num="${BASH_REMATCH[1]}"
+                    if [[ "$line" =~ ^\\(history|hist)[[:space:]]+([0-9]+)$ ]]; then
+                        local hist_num="${BASH_REMATCH[2]}"
                         local hist_index=$((hist_num - 1))
                         
                         if [ $hist_index -ge 0 ] && [ $hist_index -lt ${#CADDIE_CSV_SQL_HISTORY[@]} ]; then
@@ -777,22 +777,18 @@ function caddie_csv_sql() {
                             caddie cli:warning "History index $hist_num not found (available: 1-${#CADDIE_CSV_SQL_HISTORY[@]})"
                         fi
                     else
-                        caddie cli:warning "Usage: \\history <number> (e.g., \\history 3)"
-                        caddie cli:thought "Use \\hist to see available history numbers"
-                    fi
-                    continue
-                    ;;
-                \\hist)
-                    if [ ${#CADDIE_CSV_SQL_HISTORY[@]} -eq 0 ]; then
-                        caddie cli:warning "No SQL history available"
-                    else
-                        caddie cli:title "SQL Command History"
-                        local i
-                        for i in "${!CADDIE_CSV_SQL_HISTORY[@]}"; do
-                            local preview
-                            preview=$(caddie_csv_sql_preview_internal "${CADDIE_CSV_SQL_HISTORY[$i]}")
-                            caddie cli:indent "$((i+1)). $preview"
-                        done
+                        # No number argument - show history list
+                        if [ ${#CADDIE_CSV_SQL_HISTORY[@]} -eq 0 ]; then
+                            caddie cli:warning "No SQL history available"
+                        else
+                            caddie cli:title "SQL Command History"
+                            local i
+                            for i in "${!CADDIE_CSV_SQL_HISTORY[@]}"; do
+                                local preview
+                                preview=$(caddie_csv_sql_preview_internal "${CADDIE_CSV_SQL_HISTORY[$i]}")
+                                caddie cli:indent "$((i+1)). $preview"
+                            done
+                        fi
                     fi
                     continue
                     ;;

--- a/modules/dot_caddie_csv.sh
+++ b/modules/dot_caddie_csv.sh
@@ -505,6 +505,42 @@ function caddie_csv_sql_preview_internal() {
     return 0
 }
 
+function caddie_csv_sql_sanitize_line_internal() {
+    local input="$1"
+    input="${input//$'\e[200~'/}"
+    input="${input//$'\e[201~'/}"
+    input="${input//$'\r'/}"
+    printf '%s' "$input"
+    return 0
+}
+
+function caddie_csv_sql_handle_multiline_paste() {
+    local input="$1"
+    local buffer="$2"
+    
+    # If input contains newlines, treat it as a multiline paste
+    if [[ "$input" =~ $'\n' ]]; then
+        # Split by newlines and process each line
+        local IFS=$'\n'
+        local lines=($input)
+        local temp_buffer="$buffer"
+        
+        for line in "${lines[@]}"; do
+            line=$(caddie_csv_sql_sanitize_line_internal "$line")
+            if [ -n "$line" ]; then
+                temp_buffer+="${temp_buffer:+$'\n'}$line"
+            fi
+        done
+        
+        printf '%s' "$temp_buffer"
+        return 0
+    fi
+    
+    # Not a multiline paste, return original buffer + input
+    printf '%s' "${buffer:+$buffer$'\n'}$input"
+    return 0
+}
+
 function caddie_csv_sql_apply_internal() {
     local sql="$1"
     local mode="${2:-query}"
@@ -518,6 +554,9 @@ function caddie_csv_sql_apply_internal() {
 
     printf -v CADDIE_CSV_SQL '%s' "$sql"
     export CADDIE_CSV_SQL
+
+    # Add to SQL command history
+    caddie_csv_sql_add_to_history "$sql"
 
     caddie cli:check "SQL ready (${mode}) → $preview"
 
@@ -536,11 +575,91 @@ function caddie_csv_sql_help_internal() {
     caddie cli:indent "\\summary  Execute the current buffer as a summary query"
     caddie cli:indent "\\show     Display active CSV defaults"
     caddie cli:indent "\\history  Show the last stored SQL statement"
+    caddie cli:indent "\\hist     Show SQL command history"
+    caddie cli:indent "\\up       Go to previous command in history"
+    caddie cli:indent "\\down     Go to next command in history"
     caddie cli:indent "\\clear    Discard the in-flight SQL buffer"
+    caddie cli:indent "\\paste    Enter multiline paste mode"
     caddie cli:indent "\\help     Show this help message"
     caddie cli:blank
     caddie cli:thought "Terminate SQL with ';' to run automatically."
+    caddie cli:thought "Use \\paste for multiline queries, or type \\g after pasting."
+    caddie cli:thought "Use \\up/\\down for command history navigation."
     return 0
+}
+
+function caddie_csv_sql_paste_mode() {
+    caddie cli:title "Multiline Paste Mode"
+    caddie cli:indent "Paste your multiline SQL query below."
+    caddie cli:indent "Press Ctrl+D (EOF) when finished, or type 'END' on a new line."
+    caddie cli:blank
+    
+    local paste_buffer=""
+    local line=""
+    
+    while IFS= read -r line; do
+        if [ "$line" = "END" ]; then
+            break
+        fi
+        paste_buffer+="${paste_buffer:+$'\n'}$line"
+    done
+    
+    if [ -n "$paste_buffer" ]; then
+        # Return the pasted content to be added to the main buffer
+        printf '%s' "$paste_buffer"
+    else
+        caddie cli:warning "No content pasted"
+    fi
+    
+    return 0
+}
+
+# SQL Command History Management
+CADDIE_CSV_SQL_HISTORY=()
+CADDIE_CSV_SQL_HISTORY_INDEX=-1
+
+function caddie_csv_sql_add_to_history() {
+    local query="$1"
+    if [ -n "$query" ]; then
+        # Add to history array
+        CADDIE_CSV_SQL_HISTORY+=("$query")
+        # Keep only last 100 entries
+        if [ ${#CADDIE_CSV_SQL_HISTORY[@]} -gt 100 ]; then
+            CADDIE_CSV_SQL_HISTORY=("${CADDIE_CSV_SQL_HISTORY[@]:1}")
+        fi
+        # Reset index to end
+        CADDIE_CSV_SQL_HISTORY_INDEX=${#CADDIE_CSV_SQL_HISTORY[@]}
+    fi
+}
+
+function caddie_csv_sql_get_history_up() {
+    if [ ${#CADDIE_CSV_SQL_HISTORY[@]} -eq 0 ]; then
+        return 1
+    fi
+    
+    if [ $CADDIE_CSV_SQL_HISTORY_INDEX -gt 0 ]; then
+        CADDIE_CSV_SQL_HISTORY_INDEX=$((CADDIE_CSV_SQL_HISTORY_INDEX - 1))
+        printf '%s' "${CADDIE_CSV_SQL_HISTORY[$CADDIE_CSV_SQL_HISTORY_INDEX]}"
+        return 0
+    fi
+    return 1
+}
+
+function caddie_csv_sql_get_history_down() {
+    if [ ${#CADDIE_CSV_SQL_HISTORY[@]} -eq 0 ]; then
+        return 1
+    fi
+    
+    if [ $CADDIE_CSV_SQL_HISTORY_INDEX -lt $((${#CADDIE_CSV_SQL_HISTORY[@]} - 1)) ]; then
+        CADDIE_CSV_SQL_HISTORY_INDEX=$((CADDIE_CSV_SQL_HISTORY_INDEX + 1))
+        printf '%s' "${CADDIE_CSV_SQL_HISTORY[$CADDIE_CSV_SQL_HISTORY_INDEX]}"
+        return 0
+    fi
+    return 1
+}
+
+function caddie_csv_sql_reset_history_index() {
+    CADDIE_CSV_SQL_HISTORY_INDEX=${#CADDIE_CSV_SQL_HISTORY[@]}
 }
 
 function caddie_csv_sql() {
@@ -549,15 +668,19 @@ function caddie_csv_sql() {
     local prompt_continuation="...> "
     local buffer=""
     local line=""
-    local read_flags="-r -e"
+    local read_flags="-r"
     local previous_trap
-    if ! help read 2>/dev/null | grep -q -- '-e'; then
-        read_flags="-r"
-    fi
+    
+    # Disable readline to fix multiline paste issues
+    # This is the core fix - readline interferes with multiline paste
 
     caddie cli:title "Interactive CSV SQL prompt"
     caddie cli:indent "Enter SQL across multiple lines and finish with ';' or \\g."
     caddie cli:indent "Type \\help for available commands."
+    caddie cli:indent "Multiline paste works! Use \\up/\\down for history."
+
+    # Initialize history index
+    caddie_csv_sql_reset_history_index
 
     previous_trap=$(trap -p INT)
     trap 'buffer=""; printf "\n"; caddie cli:warning "Cancelled SQL buffer"' INT
@@ -575,6 +698,21 @@ function caddie_csv_sql() {
             fi
         fi
 
+        line=$(caddie_csv_sql_sanitize_line_internal "$line")
+
+        # Check if this might be a multiline paste (contains newlines)
+        if [[ "$line" =~ $'\n' ]]; then
+            # This contains newlines, might be a multiline paste
+            buffer=$(caddie_csv_sql_handle_multiline_paste "$line" "$buffer")
+            
+            # Check if the buffer now ends with semicolon
+            if [[ "$buffer" =~ \;[[:space:]]*$ ]]; then
+                caddie_csv_sql_apply_internal "$buffer" query
+                buffer=""
+            fi
+            continue
+        fi
+
         if [[ "$line" =~ ^\\ ]]; then
             case "$line" in
                 \\q|\\quit)
@@ -590,6 +728,23 @@ function caddie_csv_sql() {
                     caddie cli:thought "Cleared SQL buffer"
                     continue
                     ;;
+                \\paste)
+                    local pasted_content
+                    pasted_content=$(caddie_csv_sql_paste_mode)
+                    if [ -n "$pasted_content" ]; then
+                        buffer+="${buffer:+$'\n'}$pasted_content"
+                        local preview
+                        preview=$(caddie_csv_sql_preview_internal "$buffer")
+                        caddie cli:check "Added to buffer: $preview"
+                        
+                        # Check if it ends with semicolon and execute automatically
+                        if [[ "$buffer" =~ \;[[:space:]]*$ ]]; then
+                            caddie_csv_sql_apply_internal "$buffer" query
+                            buffer=""
+                        fi
+                    fi
+                    continue
+                    ;;
                 \\show)
                     caddie_csv_list
                     continue
@@ -601,6 +756,44 @@ function caddie_csv_sql() {
                         caddie cli:package "sql = $preview"
                     else
                         caddie cli:warning "SQL not set"
+                    fi
+                    continue
+                    ;;
+                \\hist)
+                    if [ ${#CADDIE_CSV_SQL_HISTORY[@]} -eq 0 ]; then
+                        caddie cli:warning "No SQL history available"
+                    else
+                        caddie cli:title "SQL Command History"
+                        local i
+                        for i in "${!CADDIE_CSV_SQL_HISTORY[@]}"; do
+                            local preview
+                            preview=$(caddie_csv_sql_preview_internal "${CADDIE_CSV_SQL_HISTORY[$i]}")
+                            caddie cli:indent "$((i+1)). $preview"
+                        done
+                    fi
+                    continue
+                    ;;
+                \\up)
+                    local history_line
+                    if history_line=$(caddie_csv_sql_get_history_up); then
+                        buffer="$history_line"
+                        local preview
+                        preview=$(caddie_csv_sql_preview_internal "$buffer")
+                        caddie cli:check "Loaded from history: $preview"
+                    else
+                        caddie cli:warning "No previous command in history"
+                    fi
+                    continue
+                    ;;
+                \\down)
+                    local history_line
+                    if history_line=$(caddie_csv_sql_get_history_down); then
+                        buffer="$history_line"
+                        local preview
+                        preview=$(caddie_csv_sql_preview_internal "$buffer")
+                        caddie cli:check "Loaded from history: $preview"
+                    else
+                        caddie cli:warning "No next command in history"
                     fi
                     continue
                     ;;
@@ -1010,7 +1203,11 @@ function caddie_csv_query() {
         env -u CADDIE_CSV_PLOT CADDIE_CSV_OUTPUT_MODE=full CADDIE_CSV_SUPPRESS_OUTPUT=0 "$script_path" "${query_args[@]}"
         status=$?
     else
-        env -u CADDIE_CSV_PLOT CADDIE_CSV_OUTPUT_MODE=full CADDIE_CSV_SUPPRESS_OUTPUT=0 "$script_path" "${query_args[@]}" | "$pager"
+        if [ "$pager" = "less" ] && [ -z "${LESS:-}" ]; then
+            env -u CADDIE_CSV_PLOT CADDIE_CSV_OUTPUT_MODE=full CADDIE_CSV_SUPPRESS_OUTPUT=0 "$script_path" "${query_args[@]}" | LESS='-R -F -X' "$pager"
+        else
+            env -u CADDIE_CSV_PLOT CADDIE_CSV_OUTPUT_MODE=full CADDIE_CSV_SUPPRESS_OUTPUT=0 "$script_path" "${query_args[@]}" | "$pager"
+        fi
         status=${PIPESTATUS[0]}
     fi
 


### PR DESCRIPTION
## Changes\n\n- bug fixes related to multiline paste and history enhancements
- bug fixes related to multiline paste and history enhancements
- bug fixes related to multiline paste and history enhancements
- improvements to the sql prompt to provide the interface to duckdb through caddie.  Supports multiline paste now and provides access to sql command history that does not interfere with the readline command history of the shell\n\n## Description\n\nThis PR includes the changes from the current branch.\n\n## Testing\n\n- [ ] Code has been tested\n- [ ] All tests pass\n- [ ] Documentation updated (if needed)